### PR TITLE
fix: treat skipped CI jobs as failure, not pending

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -4,6 +4,7 @@ on:
       - main
       - 'claude/**'  # Auto-build for all Claude branches
       - 'feature/**' # Auto-build for all feature branches
+      - 'fix/**'     # Auto-build for all fix branches
   workflow_dispatch:
 
 env:

--- a/grading/ci_checker.py
+++ b/grading/ci_checker.py
@@ -147,7 +147,7 @@ def evaluate_ci_results(check_runs: list[CheckRun]) -> CIResult:
             if run.completed_at:
                 if latest_success is None or run.completed_at > latest_success:
                     latest_success = run.completed_at
-        elif run.conclusion == "failure":
+        elif run.conclusion in ("failure", "skipped"):
             emoji = "❌"
         else:
             emoji = "⏳"

--- a/tests/test_ci_checker.py
+++ b/tests/test_ci_checker.py
@@ -180,6 +180,38 @@ class TestEvaluateCIResults:
         assert result.total_count == 0
         assert result.has_pending is True
 
+    def test_skipped_with_failure(self):
+        """Skipped job + failed job should result in failure, not pending."""
+        runs = [
+            CheckRun("run-autograding-tests", "skipped", "url1"),
+            CheckRun("Test python scripts", "failure", "url2"),
+        ]
+        result = evaluate_ci_results(runs)
+        assert result.passed is False
+        assert result.has_pending is False
+        assert "❌" in result.summary[0]
+        assert "❌" in result.summary[1]
+
+    def test_skipped_alone_is_failure(self):
+        """Skipped job alone should result in failure, not pending."""
+        runs = [
+            CheckRun("run-autograding-tests", "skipped", "url1"),
+        ]
+        result = evaluate_ci_results(runs)
+        assert result.passed is False
+        assert result.has_pending is False
+        assert result.passed_count == 0
+
+    def test_skipped_with_success_is_failure(self):
+        """Skipped + success should not pass."""
+        runs = [
+            CheckRun("lint", "skipped", "url1"),
+            CheckRun("test", "success", "url2"),
+        ]
+        result = evaluate_ci_results(runs)
+        assert result.passed is False
+        assert result.has_pending is False
+
     def test_latest_success_time(self):
         """Track latest success time."""
         runs = [


### PR DESCRIPTION
## Проблема

При проверке работы, где один из CI-джобов имел статус `skipped`, система возвращала «CI-проверки ещё выполняются ⏳» вместо сообщения о провале тестов.

**Причина:** в `evaluate_ci_results` ветка `else` обрабатывала любой статус, не являющийся `success` или `failure`, как pending — включая `skipped`. В результате `has_pending = True`, и grader возвращал PENDING вместо failure.

## Исправление

`skipped` в GitHub Actions — терминальный статус (джоб не запустился из-за условия `if:`). По смыслу совпадает с `failure`: тест не прошёл успешно.

- `grading/ci_checker.py`: объединены `"failure"` и `"skipped"` в одну ветку → ❌
- `tests/test_ci_checker.py`: добавлены 3 теста для `skipped`-сценариев

## Тесты

```
27 passed in 0.60s
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)